### PR TITLE
Use `MemoryCachedRepository` to reduce Deno KV reads

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -1,16 +1,24 @@
-import { createBot, text } from "@fedify/botkit";
+import {
+  createBot,
+  KvRepository,
+  MemoryCachedRepository,
+  text,
+} from "@fedify/botkit";
 // For development, we use in‑memory KV store and message queue.
 // For production, replace these with persistent implementations.
 import { DenoKvMessageQueue, DenoKvStore } from "@fedify/fedify/x/denokv";
 
-const kv = await Deno.openKv();
+const denoKv = await Deno.openKv();
+const kv = new DenoKvStore(denoKv);
+
 // Create your bot instance.
 const bot = createBot<void>({
   username: "bot",
   name: "HackersPub Ask Bot",
   summary: text`주기적으로 Hackers' Pub에 질문을 남기는 봇입니다.`,
-  kv: new DenoKvStore(kv),
-  queue: new DenoKvMessageQueue(kv),
+  kv,
+  queue: new DenoKvMessageQueue(denoKv),
+  repository: new MemoryCachedRepository(new KvRepository(kv)),
 });
 
 // Create the weekly post content using the new header.

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "name": "@hackerspub/ask-bot",
   "imports": {
-    "@fedify/botkit": "jsr:@fedify/botkit@^0.1.1",
-	"@fedify/fedify": "jsr:@fedify/fedify@^1.3.3"
+    "@fedify/botkit": "jsr:@fedify/botkit@^0.3.0-dev.97+783c469e",
+    "@fedify/fedify": "jsr:@fedify/fedify@^1.5.1"
   },
   "unstable": ["temporal", "cron"],
   "exports": "./bot.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -2,38 +2,38 @@
   "version": "4",
   "specifiers": {
     "jsr:@david/which-runtime@~0.2.1": "0.2.1",
-    "jsr:@fedify/botkit@~0.1.1": "0.1.1",
-    "jsr:@fedify/fedify@^1.3.3": "1.4.1",
-    "jsr:@fedify/fedify@^1.4.0": "1.4.1",
+    "jsr:@fedify/botkit@~0.3.0-dev.97+783c469e": "0.3.0-dev.97+783c469e",
+    "jsr:@fedify/fedify@^1.5.1": "1.5.1",
     "jsr:@fedify/markdown-it-hashtag@0.3": "0.3.0",
-    "jsr:@fedify/markdown-it-mention@0.2": "0.2.0",
+    "jsr:@fedify/markdown-it-mention@0.3": "0.3.0",
     "jsr:@hongminhee/x-forwarded-fetch@0.2": "0.2.0",
-    "jsr:@hono/hono@^4.6.18": "4.7.6",
+    "jsr:@hono/hono@^4.7.7": "4.7.7",
     "jsr:@hugoalh/http-header-link@^1.0.2": "1.0.3",
     "jsr:@hugoalh/is-string-singleline@^1.0.4": "1.0.4",
-    "jsr:@logtape/logtape@0.8": "0.8.2",
-    "jsr:@logtape/logtape@~0.8.1": "0.8.2",
-    "jsr:@std/async@^1.0.5": "1.0.10",
+    "jsr:@logtape/logtape@0.9": "0.9.0",
+    "jsr:@logtape/logtape@~0.8.2": "0.8.2",
+    "jsr:@std/async@^1.0.5": "1.0.12",
     "jsr:@std/bytes@^1.0.2": "1.0.5",
-    "jsr:@std/encoding@^1.0.5": "1.0.7",
+    "jsr:@std/encoding@1.0.7": "1.0.7",
     "jsr:@std/html@0.224": "0.224.2",
     "jsr:@std/html@^1.0.3": "1.0.3",
-    "jsr:@std/http@^1.0.6": "1.0.13",
-    "jsr:@std/semver@^1.0.3": "1.0.3",
-    "jsr:@std/uuid@^1.0.4": "1.0.4",
+    "jsr:@std/http@^1.0.6": "1.0.14",
+    "jsr:@std/media-types@^1.1.0": "1.1.0",
+    "jsr:@std/semver@^1.0.3": "1.0.5",
+    "jsr:@std/uuid@^1.0.6": "1.0.6",
+    "npm:@multiformats/base-x@^4.0.1": "4.0.1",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
-    "npm:@opentelemetry/semantic-conventions@^1.27.0": "1.30.0",
-    "npm:@phensley/language-tag@^1.9.0": "1.10.2",
-    "npm:@phensley/language-tag@^1.9.2": "1.10.2",
+    "npm:@opentelemetry/semantic-conventions@^1.27.0": "1.32.0",
+    "npm:@phensley/language-tag@^1.9.0": "1.12.0",
+    "npm:@phensley/language-tag@^1.9.2": "1.12.0",
     "npm:@types/markdown-it@^14.1.1": "14.1.2",
-    "npm:asn1js@^3.0.5": "3.0.5",
+    "npm:asn1js@^3.0.5": "3.0.6",
     "npm:json-canon@^1.0.1": "1.0.1",
     "npm:jsonld@^8.3.2": "8.3.3",
     "npm:markdown-it@^14.1.0": "14.1.0",
-    "npm:multibase@^4.0.6": "4.0.6",
     "npm:multicodec@^3.2.1": "3.2.1",
     "npm:pkijs@^3.2.4": "3.2.5",
-    "npm:uri-template-router@^0.0.16": "0.0.16",
+    "npm:uri-template-router@^0.0.17": "0.0.17",
     "npm:url-template@^3.1.1": "3.1.1",
     "npm:xss@^1.0.15": "1.0.15"
   },
@@ -41,40 +41,41 @@
     "@david/which-runtime@0.2.1": {
       "integrity": "2a304e36b1122ebfe384d45de8fe0fb2bfe54a0a5a2a596efbfc81f54a47a62d"
     },
-    "@fedify/botkit@0.1.1": {
-      "integrity": "086f55232ecc5f5c0cfb94b0bff99b8fbd527b5dc3a68e4e84a7f1fbc6fd8264",
+    "@fedify/botkit@0.3.0-dev.97+783c469e": {
+      "integrity": "b42a5eb64e3a17a59f6b943262bd694407f8f6b9e18cec3c1179bb0a0096c4be",
       "dependencies": [
-        "jsr:@fedify/fedify@^1.4.0",
+        "jsr:@fedify/fedify",
         "jsr:@fedify/markdown-it-hashtag",
         "jsr:@fedify/markdown-it-mention",
         "jsr:@hongminhee/x-forwarded-fetch",
         "jsr:@hono/hono",
-        "jsr:@logtape/logtape@0.8",
+        "jsr:@logtape/logtape@0.9",
         "jsr:@std/html@^1.0.3",
+        "jsr:@std/media-types",
         "jsr:@std/uuid",
         "npm:@phensley/language-tag@^1.9.2",
         "npm:markdown-it",
         "npm:xss"
       ]
     },
-    "@fedify/fedify@1.4.1": {
-      "integrity": "a96f272b55b5ded0b77b6a89b1f4406641e4a1dae6a79cde0d15c1d4612b0293",
+    "@fedify/fedify@1.5.1": {
+      "integrity": "1034b476f0f92a3a2a42f39f85c087742e1a859804698785705afa81aeb2e742",
       "dependencies": [
         "jsr:@david/which-runtime",
         "jsr:@hugoalh/http-header-link",
-        "jsr:@logtape/logtape@~0.8.1",
+        "jsr:@logtape/logtape@~0.8.2",
         "jsr:@std/async",
         "jsr:@std/bytes",
         "jsr:@std/encoding",
         "jsr:@std/http",
         "jsr:@std/semver",
+        "npm:@multiformats/base-x",
         "npm:@opentelemetry/api",
         "npm:@opentelemetry/semantic-conventions",
         "npm:@phensley/language-tag@^1.9.0",
         "npm:asn1js",
         "npm:json-canon",
         "npm:jsonld",
-        "npm:multibase",
         "npm:multicodec",
         "npm:pkijs",
         "npm:uri-template-router",
@@ -88,8 +89,8 @@
         "npm:@types/markdown-it"
       ]
     },
-    "@fedify/markdown-it-mention@0.2.0": {
-      "integrity": "98706e8dfafb0ce45c781e2e7162400be4d9c71f80c5a1671d7209086b9ba6a3",
+    "@fedify/markdown-it-mention@0.3.0": {
+      "integrity": "f643f850da6310566a1de2744900d7bc06c0f59d3ae9a14202a6d968f5d20227",
       "dependencies": [
         "jsr:@std/html@0.224",
         "npm:@types/markdown-it"
@@ -98,8 +99,8 @@
     "@hongminhee/x-forwarded-fetch@0.2.0": {
       "integrity": "8a347e061974e07b480e9461c7d84047e12e92c462fe7679a6f0f59b5c5f48d5"
     },
-    "@hono/hono@4.7.6": {
-      "integrity": "407da752c13d4644bb9d363f8349db7542e21abc3db8c13ca90cf69d8ab675ad"
+    "@hono/hono@4.7.7": {
+      "integrity": "74ea9985cb405fada079a922538f6baa06fa1ee150ce409c5bdae2c89ac05cba"
     },
     "@hugoalh/http-header-link@1.0.3": {
       "integrity": "3372096a73d755e3351f7fbd7155db7725874c2682a594a655580e3866563024",
@@ -113,8 +114,11 @@
     "@logtape/logtape@0.8.2": {
       "integrity": "e2ae1fc2561e8d010359b9894efb39bdb559dae44f5824540cbb26a78eee36bc"
     },
-    "@std/async@1.0.10": {
-      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    "@logtape/logtape@0.9.0": {
+      "integrity": "aacdeb0e040e5723021bef8b9b8c03ad7cffb5e2146a0024c30814930f6e7c89"
+    },
+    "@std/async@1.0.12": {
+      "integrity": "d1bfcec459e8012846fe4e38dfc4241ab23240ecda3d8d6dfcf6d81a632e803d"
     },
     "@std/bytes@1.0.5": {
       "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
@@ -128,14 +132,17 @@
     "@std/html@1.0.3": {
       "integrity": "7a0ac35e050431fb49d44e61c8b8aac1ebd55937e0dc9ec6409aa4bab39a7988"
     },
-    "@std/http@1.0.13": {
-      "integrity": "d29618b982f7ae44380111f7e5b43da59b15db64101198bb5f77100d44eb1e1e"
+    "@std/http@1.0.14": {
+      "integrity": "bfc4329d975dff2abd8170e83e37deb454fbc678fec3fdd2ef5b03d92768a4ef"
     },
-    "@std/semver@1.0.3": {
-      "integrity": "7c139c6076a080eeaa4252c78b95ca5302818d7eafab0470d34cafd9930c13c8"
+    "@std/media-types@1.1.0": {
+      "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
     },
-    "@std/uuid@1.0.4": {
-      "integrity": "f4233149cc8b4753cc3763fd83a7c4101699491f55c7be78dc7b30281946d7a0"
+    "@std/semver@1.0.5": {
+      "integrity": "529f79e83705714c105ad0ba55bec0f9da0f24d2f726b6cc1c15e505cc2c0624"
+    },
+    "@std/uuid@1.0.6": {
+      "integrity": "f3ca728cad488a4bed271974e43721c379ad25a0ae17be7967edee036beba9c5"
     }
   },
   "npm": {
@@ -153,17 +160,17 @@
     "@multiformats/base-x@4.0.1": {
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
-    "@noble/hashes@1.7.1": {
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
+    "@noble/hashes@1.8.0": {
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
     },
     "@opentelemetry/api@1.9.0": {
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
-    "@opentelemetry/semantic-conventions@1.30.0": {
-      "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw=="
+    "@opentelemetry/semantic-conventions@1.32.0": {
+      "integrity": "sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ=="
     },
-    "@phensley/language-tag@1.10.2": {
-      "integrity": "sha512-Xdui/GVDztdYb9oGzysHRRnakD9FKJIRIRTYvq5SoeGmglAgtDXOLEAm+yTMl8sqMr6AdVCz3/kH7F9wNeGnSQ==",
+    "@phensley/language-tag@1.12.0": {
+      "integrity": "sha512-d6P4riI4XFlscmx1dOSzDv2P7rKRp9HI8u9Kx3hXRYvsXVtarwsJzDMyHNaItzcMhdoH8YWErUa0OUVFVW1dbw==",
       "dependencies": [
         "tslib"
       ]
@@ -190,8 +197,8 @@
     "argparse@2.0.1": {
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "asn1js@3.0.5": {
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+    "asn1js@3.0.6": {
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
       "dependencies": [
         "pvtsutils",
         "pvutils",
@@ -281,12 +288,6 @@
     "mdurl@2.0.0": {
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
-    "multibase@4.0.6": {
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "dependencies": [
-        "@multiformats/base-x"
-      ]
-    },
     "multicodec@3.2.1": {
       "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
       "dependencies": [
@@ -358,8 +359,8 @@
         "@fastify/busboy"
       ]
     },
-    "uri-template-router@0.0.16": {
-      "integrity": "sha512-kvIuR8BtfL/VXFCM5hA7kjfYBdxMKQMmjOOA2zPUR1Xy7K+aVF2cVWMDaQEa2O74WN7zMloyvvmYjNJ38fVUew=="
+    "uri-template-router@0.0.17": {
+      "integrity": "sha512-5h2I/eSN+XFRAFaSR72KTFWg5rf8GB6Ur5+yWHjtwEqmn6cfZqoWsoWTh6NhxW8pIlFq144G2J23OCg3CeAaSg=="
     },
     "url-template@3.1.1": {
       "integrity": "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA=="
@@ -389,8 +390,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@fedify/botkit@~0.1.1",
-      "jsr:@fedify/fedify@^1.3.3"
+      "jsr:@fedify/botkit@~0.3.0-dev.97+783c469e",
+      "jsr:@fedify/fedify@^1.5.1"
     ]
   }
 }


### PR DESCRIPTION
This change aims to reduce Deno KV reads for cost efficiency on Deno Deploy. Since [`MemoryCachedRepository`] is an experimental feature from BotKit 0.3.0, which is not released yet, I bumped the version of BotKit to [v0.3.0-dev.97+783c469e].

[`MemoryCachedRepository`]: https://botkit.fedify.dev/concepts/repository#memorycachedrepository
[v0.3.0-dev.97+783c469e]: https://jsr.io/@fedify/botkit@0.3.0-dev.97+783c469e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency versions for improved compatibility and performance.  
- **Refactor**
  - Improved data storage and caching layers for better efficiency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->